### PR TITLE
Compute Squat Similarity Scores

### DIFF
--- a/stance/motion/Motion.py
+++ b/stance/motion/Motion.py
@@ -25,11 +25,12 @@ class Motion(ABC):
         """
         raise NotImplementedError
 
-    @staticmethod
+
     @abstractmethod
     def find_benchmark_zones_of_user(user_skeletons):
         """
-        Compares two skeletons to determine how similar the two skeletons are.
+        Find which user skeletons map closest to the template
+        skeletons
 
         Parameters
         ----------
@@ -43,7 +44,7 @@ class Motion(ABC):
         """
         raise NotImplementedError
 
-    @staticmethod
+
     @abstractmethod
     def score(user_skeletons):
         """

--- a/stance/motion/Motion.py
+++ b/stance/motion/Motion.py
@@ -27,7 +27,7 @@ class Motion(ABC):
 
 
     @abstractmethod
-    def find_benchmark_zones_of_user(user_skeletons):
+    def find_benchmark_zones_of_user(self, user_skeletons):
         """
         Find which user skeletons map closest to the template
         skeletons
@@ -46,7 +46,7 @@ class Motion(ABC):
 
 
     @abstractmethod
-    def score(user_skeletons):
+    def score(self, user_skeletons):
         """
         Uses user's skeleton to make a score value that defines how close the user
         is to performing the motion perfectly.

--- a/stance/motion/squat.py
+++ b/stance/motion/squat.py
@@ -40,8 +40,7 @@ class Squat(Motion):
         float
             cumulative similarity score between this and other
         """
-        scored_vectors = ('l_lower_leg', 'r_lower_leg', 'l_upper_leg', 'r_upper_leg',
-                          'l_spine', 'r_spine')
+        scored_vectors = ('l_lower_leg', 'l_upper_leg', 'l_spine')
         def _compare(label: str):
             u = this.vectors[label]
             v = other.vectors[label]

--- a/stance/motion/squat.py
+++ b/stance/motion/squat.py
@@ -1,4 +1,5 @@
 from .Motion import Motion
+from functools import partial
 
 
 class Squat(Motion):
@@ -7,38 +8,46 @@ class Squat(Motion):
 
     # --------------- IMPLEMENTED ABSTRACT METHODS ------------------
 
-    @staticmethod
-    def find_benchmark_zones_of_user(user_skeletons):
+    def find_benchmark_zones_of_user(self, user_skeletons: Sequence[Skeleton]) -> Sequence[Skeleton]:
         """
         SEE MOTION DOCSTRING
         """
-        # --------------- SKELETON SIMILARITY SCORES ------------------
-        def _0_similarity(user_skeleton):
-            # TODO Implement this method
-            return 0
+        benchmark_zones = []
+        for template in template_skeletons:
+            cmp = partial(Squat.compare_skeletons, template)
+            benchmark_zones.append(max(user_skeletons, key=cmp))
+        return benchmark_zones
 
-        def _1_similarity(user_skeleton):
-            # TODO Implement this method
-            return 1
 
-        def _2_similarity(user_skeleton):
-            # TODO Implement this method
-            return 2
+    @staticmethod
+    def compare_skeletons(this, other: Skeleton) -> float:
+        """
+        Gives a normalized similarity score between two skeletons by summing
+        the cosine similarities of each scored body part vector. If one or both
+        vectors are None, then the similarity is defined to be 0
 
-        def _3_similarity(user_skeleton):
-            # TODO Implement this method
-            return 3
+        Parameters
+        ----------
+        this, other : Skeleton
+            Two skeletons to compare
 
-        def _4_similarity(user_skeleton):
-            # TODO Implement this method
-            return 4
+        Returns
+        -------
+        float
+            cumulative similarity score between this and other
+        """
+        scored_vectors = ('l_lower_leg', 'r_lower_leg', 'l_upper_leg', 'r_upper_leg',
+                          'l_spine', 'r_spine')
+        def _compare(s):
+            u = this.vectors[s]
+            v = other.vectors[s]
+            if u is None or v is None:
+                return 0
+            return u.cos_similarity(v)
 
-        similarity_scorers = [_0_similarity, _1_similarity, _2_similarity,
-                              _3_similarity, _4_similarity]
+        return sum(map(_compare, scored_vectors)) / (len(scored_vectors))
 
-        idxs = range(len(user_skeletons))
-        return [min(idxs, key=lambda i: scorer(i))
-                for scorer in similarity_scorers]
+
 
     def create_template_skeletons(self, front_view_points, profile_view_points):
 
@@ -66,32 +75,33 @@ class Squat(Motion):
         benchmark_zones = [_0, _1, _2, _3, _4]
         return [zone(front_view_points, profile_view_points) for zone in benchmark_zones]
 
-    @staticmethod
-    def score(user_skeletons):
+
+    def score(self, user_skeletons):
 
         # --------------- SKELETON SCORERS ------------------
         # Each score is from range [0, 20] so that total is out of 100
+        # TODO or we could just normalize
 
-        def _0_score(user_skeleton):
-            # TODO Implement this method
-            return 0
+        # def _0_score(user_skeleton):
+        #     # TODO Implement this method
+        #     return 0
 
-        def _1_score(user_skeleton):
-            # TODO Implement this method
-            return 1
+        # def _1_score(user_skeleton):
+        #     # TODO Implement this method
+        #     return 1
 
-        def _2_score(user_skeleton):
-            # TODO Implement this method
-            return 2
+        # def _2_score(user_skeleton):
+        #     # TODO Implement this method
+        #     return 2
 
-        def _3_score(user_skeleton):
-            # TODO Implement this method
-            return 3
+        # def _3_score(user_skeleton):
+        #     # TODO Implement this method
+        #     return 3
 
-        def _4_score(user_skeleton):
-            # TODO Implement this method
-            return 4
+        # def _4_score(user_skeleton):
+        #     # TODO Implement this method
+        #     return 4
 
-        scorers = [_0_score, _1_score, _2_score, _3_score, _4_score]
-        assert len(user_skeletons) == len(scorers), "Must have as many skeletons as scorers"
-        return sum(scorer(skeleton) for scorer, skeleton in zip(scorers, user_skeletons))
+        # scorers = [_0_score, _1_score, _2_score, _3_score, _4_score]
+        # assert len(user_skeletons) == len(scorers), "Must have as many skeletons as scorers"
+        # return sum(scorer(skeleton) for scorer, skeleton in zip(scorers, user_skeletons))

--- a/stance/motion/squat.py
+++ b/stance/motion/squat.py
@@ -1,10 +1,14 @@
-from .Motion import Motion
 from functools import partial
+from typing import Sequence
+
+from skeleton.skeleton import Skeleton
+from .Motion import Motion
 
 
 class Squat(Motion):
     def __init__(self, front_view_points, profile_view_points):
-        self.template_skeletons = self.create_template_skeletons(front_view_points, profile_view_points)
+        self.template_skeletons = self.create_template_skeletons(front_view_points,
+                                                                 profile_view_points)
 
     # --------------- IMPLEMENTED ABSTRACT METHODS ------------------
 
@@ -13,7 +17,7 @@ class Squat(Motion):
         SEE MOTION DOCSTRING
         """
         benchmark_zones = []
-        for template in template_skeletons:
+        for template in self.template_skeletons:
             cmp = partial(Squat.compare_skeletons, template)
             benchmark_zones.append(max(user_skeletons, key=cmp))
         return benchmark_zones
@@ -38,9 +42,9 @@ class Squat(Motion):
         """
         scored_vectors = ('l_lower_leg', 'r_lower_leg', 'l_upper_leg', 'r_upper_leg',
                           'l_spine', 'r_spine')
-        def _compare(s):
-            u = this.vectors[s]
-            v = other.vectors[s]
+        def _compare(label: str):
+            u = this.vectors[label]
+            v = other.vectors[label]
             if u is None or v is None:
                 return 0
             return u.cos_similarity(v)
@@ -105,3 +109,4 @@ class Squat(Motion):
         # scorers = [_0_score, _1_score, _2_score, _3_score, _4_score]
         # assert len(user_skeletons) == len(scorers), "Must have as many skeletons as scorers"
         # return sum(scorer(skeleton) for scorer, skeleton in zip(scorers, user_skeletons))
+        pass


### PR DESCRIPTION
Adds functionality via `compare_skeletons` to compute cumulative
similarity scores between skeletons. This is used in
`find_benchmark_zones_of_user` to identify the closest user skeleton to
each template skeleton.
